### PR TITLE
GLOB-42559 - Fix High Severity Exploitable Code Dependency Vulnerability - lodash

### DIFF
--- a/{{cookiecutter.project_name}}/package.json
+++ b/{{cookiecutter.project_name}}/package.json
@@ -13,7 +13,7 @@
         "verify": "yarn lint && yarn test"
     },
     "dependencies": {
-        "lodash": "^4.17.5"
+        "lodash": "4.17.11"
     },
     "devDependencies": {
         "babel-cli": "^6.26.0",

--- a/{{cookiecutter.project_name}}/package.json
+++ b/{{cookiecutter.project_name}}/package.json
@@ -13,7 +13,7 @@
         "verify": "yarn lint && yarn test"
     },
     "dependencies": {
-        "lodash": "4.17.11"
+        "lodash": "^4.17.12"
     },
     "devDependencies": {
         "babel-cli": "^6.26.0",


### PR DESCRIPTION
GitHub repositories have an outdated version of lodash and are at risk of a high severity and exploitable code dependency vulnerabilities (CVSS 7.3) . Please update the lodash package for the below Github repositories to, at a minimum, version 4.17.12.

JIRA - https://globality.atlassian.net/browse/GLOB-42559

